### PR TITLE
Add org-auto-tangle-default variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,17 +24,19 @@ Simply require the package in you emacs init and hook it into org-mode.
 or you can use use-package
 
 #+begin_src emacs-lisp
-
 (use-package org-auto-tangle
   :load-path "site-lisp/org-auto-tangle/"    ;; this line is necessary only if you cloned the repo in your site-lisp directory 
   :defer t
   :hook (org-mode . org-auto-tangle-mode))
-
 #+end_src
 
 If the minor mode is on, it will try to automatically tangle
 your org files if they contain a non nil value for the
 ~#+auto_tangle:~ option.
+
+You can configure auto-tangle as the default behavior for all org buffers by
+setting the ~org-auto-tangle-default~ variable to ~t~. In this case, you can disable
+it for some buffers by setting the ~#+auto_tangle:~ option to ~nil~.
 
 * License
 

--- a/org-auto-tangle.el
+++ b/org-auto-tangle.el
@@ -48,16 +48,16 @@
 
 (require 'async)
 
+(defvar org-auto-tangle-default nil
+  "Default behavior of org-auto-tangle.
 
-(defun org-auto-tangle-find-value (buffer)
-  "Search the `auto_tangle' property in BUFFER and extracts it when found."
-  (with-current-buffer buffer
-    (save-restriction
-      (widen)
-      (save-excursion
-	(goto-char (point-min))
-	(when (re-search-forward "^#\\+auto_tangle:[ \t]+\\([^ \f\t\n\r\v]+\\)[ \t]*" nil :noerror)
-	  (match-string 1))))))
+If nil (default), auto-tangle will only happen on buffers with
+the `#+auto_tangle: t' keyword. If t, auto-tangle will happen on
+all Org buffers unless `#+auto_tangle: nil' is set.")
+
+(defun org-auto-tangle-find-value ()
+  "Search the `auto_tangle' property in the current buffer and extracts it when found."
+  (cadar (org-collect-keywords '("auto_tangle"))))
 
 (defun org-auto-tangle-async (file)
   "Invoke `org-babel-tangle-file' asynchronously on FILE."
@@ -73,21 +73,29 @@
      `(lambda (tangle-time)
 	(message "%s %s seconds",message-string tangle-time)))))
 
-(defun org-auto-tangle-tangle-if-tag-exists ()
-  "Check if the #+auto_tangle option exists and call org-auto-tangle-async if it exists."
-  (when (and (eq major-mode 'org-mode)
-	     (org-auto-tangle-find-value (current-buffer))
-	     (not (string= (org-auto-tangle-find-value(current-buffer)) "nil")))
-    (org-auto-tangle-async (buffer-file-name))))
+(defun org-auto-tangle-tangle-if-needed ()
+  "Call org-auto-tangle-async if needed.
+
+Tangle will happen depending on the value of
+`org-auto-tangle-default' and on the presence and value of the
+`#+auto_tangle' keyword in the current buffer. If present,
+`#+auto_tangle' always overrides `org-auto-tangle-default'."
+  (let ((auto-tangle-kw (org-auto-tangle-find-value)))
+    (when (and (eq major-mode 'org-mode)
+	       (or (and auto-tangle-kw
+	                (not (string= auto-tangle-kw "nil")))
+                   (and (not auto-tangle-kw)
+                        org-auto-tangle-default)))
+      (org-auto-tangle-async (buffer-file-name)))))
 
 (define-minor-mode org-auto-tangle-mode
   "Automatically tangle org-mode files with the option #+auto_tangle: t."
   :lighter " org-a-t"
 
   (if org-auto-tangle-mode
-	      (add-hook 'after-save-hook #'org-auto-tangle-tangle-if-tag-exists
+	      (add-hook 'after-save-hook #'org-auto-tangle-tangle-if-needed
 			nil 'local)
-    (remove-hook 'after-save-hook #'org-auto-tangle-tangle-if-tag-exists 'local)))
+    (remove-hook 'after-save-hook #'org-auto-tangle-tangle-if-needed 'local)))
 
 (provide 'org-auto-tangle)
 

--- a/org-auto-tangle.el
+++ b/org-auto-tangle.el
@@ -55,9 +55,15 @@ If nil (default), auto-tangle will only happen on buffers with
 the `#+auto_tangle: t' keyword. If t, auto-tangle will happen on
 all Org buffers unless `#+auto_tangle: nil' is set.")
 
-(defun org-auto-tangle-find-value ()
-  "Search the `auto_tangle' property in the current buffer and extracts it when found."
-  (cadar (org-collect-keywords '("auto_tangle"))))
+(defun org-auto-tangle-find-value (buffer)
+  "Search the `auto_tangle' property in BUFFER and extracts it when found."
+  (with-current-buffer buffer
+    (save-restriction
+      (widen)
+      (save-excursion
+	(goto-char (point-min))
+	(when (re-search-forward "^#\\+auto_tangle: \\(.*\\)" nil :noerror)
+	  (match-string 1))))))
 
 (defun org-auto-tangle-async (file)
   "Invoke `org-babel-tangle-file' asynchronously on FILE."


### PR DESCRIPTION
This PR makes the following changes:

- Introduce a new variable org-auto-tangle-default which determines the
  default behavior. With its default value of nil, the behavior remains
  unchanged, with auto-tangling enabled for files with the
  #+auto_tangle: t option. If set to t, the default is to auto-tangle
  all org files, and it can be disabled by setting #+auto_tangle: nil.
  If present, the value of #+auto_tangle always overrides the default.
  This addresses #4.

- Simplified org-auto-tangle-find-value by using the built-in function
  org-collect-keywords.