### PR TITLE
Permit code block evaluation for files in safelist

### DIFF
--- a/org-auto-tangle.el
+++ b/org-auto-tangle.el
@@ -56,6 +56,13 @@ If nil (default), auto-tangle will only happen on buffers with
 the `#+auto_tangle: t' keyword. If t, auto-tangle will happen on
 all Org buffers unless `#+auto_tangle: nil' is set.")
 
+(defvar org-auto-tangle-babel-safelist '()
+  "List of full path of files for which code blocks need to be evaluated.
+
+By default, code blocks are not evaluated during the auto-tangle to avoid
+possible code execution from unstrusted source. To enable code blocks evaluation
+for a specific file, add its full path to this list.")
+
 (defun org-auto-tangle-find-value (buffer)
   "Search the `auto_tangle' property in BUFFER and extracts it when found."
   (with-current-buffer buffer
@@ -74,7 +81,8 @@ all Org buffers unless `#+auto_tangle: nil' is set.")
      `(lambda ()
 	(require 'org)
 	(let ((start-time (current-time))
-	      (non-essential t))
+	      (non-essential t)
+	      (org-confirm-babel-evaluate (not (member ,file ',org-auto-tangle-babel-safelist))))
 	  (apply #'org-babel-tangle-file ',args)
 	  (format "%.2f" (float-time (time-since start-time))))))
    (let ((message-string (format "Tangling %S completed after" file)))


### PR DESCRIPTION
By default, evaluation of code blocks is disabled (`org-confirm-babel-evaluate` is `t` by default in async Emacs process). If the org file contains section like this :
```
#+NAME: lsp-dir
#+begin_src emacs-lisp :tangle no
(expand-file-name "var/lsp/server" user-emacs-directory)
#+end_src
```
The auto-tangle process does not work :
- with Emacs 27, the async process does not end (like issue #11)
- with Emacs 28, `lsp-dir` is set to `nil` and so is unusable

As code block evaluation can lead to code execution form untrusted org-file, it's dangerous to enabled it globally. This PR define a safelist variable in order to enable code block evaluation only for an explicit list of files.