### PR TITLE
Pass user-specified variables to the async process

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,6 +38,28 @@ You can configure auto-tangle as the default behavior for all org buffers by
 setting the ~org-auto-tangle-default~ variable to ~t~. In this case, you can disable
 it for some buffers by setting the ~#+auto_tangle:~ option to ~nil~.
 
+The ~#+auto_tangle:~ option may also be used to specify variables that should be
+preserved in the asynchronous tangling process. For example, if you have
+installed a newer version of ~org-mode~ or additional Babel processors, using
+
+#+begin_src org
+  #+auto_tangle: vars:load-path
+#+end_src
+
+will be sure that they are available during tangling. The ~vars~ option takes a
+colon-separated list so multiple variables may be specified
+
+#+begin_src org
+  #+auto_tangle: vars:calendar-longitude:calendar-latitude:calendar-location-name
+#+end_src
+
+It is also possible to disable auto-tangling by adding the ~nil~ option to the 
+line without removing any ~vars~ list.
+
+#+begin_src org
+  #+auto_tangle: vars:load-path nil
+#+end_src
+
 * Babel Auto Tangle Safelist
 Add a list of files to the safelist to autotangle with noweb evaluation
 #+begin_src emacs-lisp


### PR DESCRIPTION
I have a special use case for tangling my Emacs configuration where I needed some calendar variables passed to the asynchronous Emacs tangling process. This PR enhances `#+auto_tangle` with support for a colon separated `vars` list that may be set on a per-file basis.  Any variables named here will be added to the `preserved` list that is passed to the async.

It may also address issue #16 by allowing the user to specify

```#+auto_tangle vars:load-path```

in case their `ob-python` is not in the default Emacs `load-path`.

The following changes were made:

- Augment the `auto_tangle` keyword to handle a `vars` option which contains a colon-separated list of variable names that will be passed and preserved in the async tangling process.

- Add an `org-auto-tangle` configuration group.

- Add an `org-auto-tangle-with-vars` configuration option.

- Support disabling auto-tangling by adding `nil` to the `AUTO_TANGLE` keyword line without having to remove any variables that are set there.

The implementation uses some functionality from org-export (ox) which would allow for extending `#+auto_tangle` in the future.

In case you pick this up, I will also submit another PR that adds the existing org-auto-tangle variables to the customization group. It is on my [customization branch](https://github.com/rdparker/org-auto-tangle/tree/customization) and is currently dependent upon this change, see [commit e0d1fbe](https://github.com/rdparker/org-auto-tangle/commit/e0d15be9fd7c70be3f45150f62cb6decf77a8945) there.